### PR TITLE
Moves guest initialization to eager

### DIFF
--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -7,18 +7,16 @@ import (
 )
 
 // Middleware is a factory of handler instances implemented in Wasm.
-type Middleware[H any, N api.Closer] interface {
-	// TODO: Can Go generics can be more precise like "N api.Closer & H"?
-
+type Middleware[H any] interface {
 	// NewHandler creates an HTTP server handler implemented by a WebAssembly
-	// module. The returned handler will not invoke FuncNext when it obviates a
-	// request for reasons such as an authorization failure or serving from
-	// cache.
+	// module. The returned handler will not invoke FuncNext when it calls
+	// FuncSendResponse for reasons such as an authorization failure or serving
+	// from cache.
 	//
 	// ## Notes
 	//   - Each handler is independent, so they don't share memory.
 	//   - Handlers returned are not safe for concurrent use.
-	NewHandler(ctx context.Context, next H) (N, error)
+	NewHandler(ctx context.Context, next H) H
 
 	api.Closer
 }

--- a/handler/fasthttp/example_test.go
+++ b/handler/fasthttp/example_test.go
@@ -39,11 +39,7 @@ func Example_auth() {
 	defer mw.Close(ctx)
 
 	// Wrap the real handler with an interceptor implemented in WebAssembly.
-	wrapped, err := mw.NewHandler(ctx, serveJson)
-	if err != nil {
-		log.Panicln(err)
-	}
-	defer wrapped.Close(ctx)
+	wrapped := mw.NewHandler(ctx, serveJson)
 
 	// Start the server with the wrapped handler.
 	ts, url := listenAndServe(wrapped)
@@ -100,11 +96,7 @@ func Example_log() {
 	defer mw.Close(ctx)
 
 	// Wrap the real handler with an interceptor implemented in WebAssembly.
-	wrapped, err := mw.NewHandler(ctx, serveJson)
-	if err != nil {
-		log.Panicln(err)
-	}
-	defer wrapped.Close(ctx)
+	wrapped := mw.NewHandler(ctx, serveJson)
 
 	// Start the server with the wrapped handler.
 	ts, url := listenAndServe(wrapped)
@@ -137,11 +129,7 @@ func Example_router() {
 	defer mw.Close(ctx)
 
 	// Wrap the real handler with an interceptor implemented in WebAssembly.
-	wrapped, err := mw.NewHandler(ctx, servePath)
-	if err != nil {
-		log.Panicln(err)
-	}
-	defer wrapped.Close(ctx)
+	wrapped := mw.NewHandler(ctx, servePath)
 
 	// Start the server with the wrapped handler.
 	ts, url := listenAndServe(wrapped)
@@ -170,8 +158,8 @@ func Example_router() {
 	// /a
 }
 
-func listenAndServe(wrapped RequestHandler) (*fasthttp.Server, string) {
-	ts := &fasthttp.Server{Handler: wrapped.Handle}
+func listenAndServe(wrapped fasthttp.RequestHandler) (*fasthttp.Server, string) {
+	ts := &fasthttp.Server{Handler: wrapped}
 	ln, err := net.Listen("tcp4", "127.0.0.1:")
 	if err != nil {
 		log.Panicln(err)

--- a/handler/fasthttp/middleware_test.go
+++ b/handler/fasthttp/middleware_test.go
@@ -1,9 +1,13 @@
 package wasm
 
-import "github.com/http-wasm/http-wasm-host-go/api/handler"
+import (
+	"github.com/valyala/fasthttp"
+
+	"github.com/http-wasm/http-wasm-host-go/api/handler"
+)
 
 // compile-time check to ensure host implements handler.Host.
 var _ handler.Host = host{}
 
-// compile-time check to ensure guest implements RequestHandler.
-var _ RequestHandler = &guest{}
+// compile-time check to ensure guest implements fasthttp.RequestHandler.
+var _ fasthttp.RequestHandler = (&guest{}).Handle

--- a/handler/nethttp/example_test.go
+++ b/handler/nethttp/example_test.go
@@ -38,11 +38,7 @@ func Example_auth() {
 	next := serveJson
 
 	// Wrap this with an interceptor implemented in WebAssembly.
-	wrapped, err := mw.NewHandler(ctx, next)
-	if err != nil {
-		log.Panicln(err)
-	}
-	defer wrapped.Close(ctx)
+	wrapped := mw.NewHandler(ctx, next)
 
 	// Start the server with the wrapped handler.
 	ts := httptest.NewServer(wrapped)
@@ -102,11 +98,7 @@ func Example_log() {
 	next := serveJson
 
 	// Wrap this with an interceptor implemented in WebAssembly.
-	wrapped, err := mw.NewHandler(ctx, next)
-	if err != nil {
-		log.Panicln(err)
-	}
-	defer wrapped.Close(ctx)
+	wrapped := mw.NewHandler(ctx, next)
 
 	// Start the server with the wrapped handler.
 	ts := httptest.NewServer(wrapped)
@@ -139,11 +131,7 @@ func Example_router() {
 	defer mw.Close(ctx)
 
 	// Wrap the real handler with an interceptor implemented in WebAssembly.
-	wrapped, err := mw.NewHandler(ctx, servePath)
-	if err != nil {
-		log.Panicln(err)
-	}
-	defer wrapped.Close(ctx)
+	wrapped := mw.NewHandler(ctx, servePath)
 
 	// Start the server with the wrapped handler.
 	ts := httptest.NewServer(wrapped)

--- a/handler/nethttp/middleware_test.go
+++ b/handler/nethttp/middleware_test.go
@@ -1,9 +1,13 @@
 package wasm
 
-import "github.com/http-wasm/http-wasm-host-go/api/handler"
+import (
+	"net/http"
+
+	"github.com/http-wasm/http-wasm-host-go/api/handler"
+)
 
 // compile-time check to ensure host implements handler.Host.
 var _ handler.Host = host{}
 
-// compile-time check to ensure guest implements Handler.
-var _ Handler = &guest{}
+// compile-time check to ensure guest implements http.Handler.
+var _ http.Handler = &guest{}


### PR DESCRIPTION
This sets up the stage for internal module pooling later and simplifies the API.
