### PR TITLE
Only call ExportedFunction once

### DIFF
--- a/internal/handler/abi.go
+++ b/internal/handler/abi.go
@@ -60,8 +60,9 @@ func (r *Runtime) Close(ctx context.Context) error {
 }
 
 type Guest struct {
-	ns    wazero.Namespace
-	guest wazeroapi.Module
+	ns     wazero.Namespace
+	guest  wazeroapi.Module
+	handle wazeroapi.Function
 }
 
 func (r *Runtime) NewGuest(ctx context.Context) (*Guest, error) {
@@ -83,12 +84,12 @@ func (r *Runtime) NewGuest(ctx context.Context) (*Guest, error) {
 		return nil, fmt.Errorf("wasm: error instantiating guest: %w", err)
 	}
 
-	return &Guest{ns: ns, guest: guest}, nil
+	return &Guest{ns: ns, guest: guest, handle: guest.ExportedFunction(handler.FuncHandle)}, nil
 }
 
 // Handle calls the WebAssembly function export "handle".
 func (g *Guest) Handle(ctx context.Context) (err error) {
-	_, err = g.guest.ExportedFunction(handler.FuncHandle).Call(ctx)
+	_, err = g.handle.Call(ctx)
 	return
 }
 


### PR DESCRIPTION
This is important ever since the call engine refactoring.

Did actually notice it in code review but wasn't confident without the benchmark to confirm :)

After
```
Benchmark_httpwasm_tinygo
Benchmark_httpwasm_tinygo-10    	  149740	      7940 ns/op
Benchmark_httpwasm_wat
Benchmark_httpwasm_wat-10       	  194221	      6163 ns/op
```

Before
```
Benchmark_httpwasm_tinygo
Benchmark_httpwasm_tinygo-10    	  125712	      9435 ns/op
Benchmark_httpwasm_wat
Benchmark_httpwasm_wat-10       	  136298	      7470 ns/op
```