### PR TITLE
Add pooling of initialized wasm guests

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -1,0 +1,15 @@
+# Notable rationale of http-wasm-host-go
+
+## Guest pool
+
+Wasm guests may have static initialization logic that takes significant time,
+for example parsing a config file. Because Wasm is not thread-safe, we cannot
+use a single instance to handle requests concurrently and instead have a pool
+of initialized guests.
+
+The pool size is uncapped - any pool size cap would be a concurrency limit on
+the request handler. Production HTTP servers all have a native concept of
+concurrency limiting, so it would be redundant to have another way to limit
+concurrency here. Memory used by the middleware is similar to end-user business
+logic, and high memory usage in either would be handled the same way, by the
+HTTP server's concurrency limit mechanism.

--- a/handler/fasthttp/middleware.go
+++ b/handler/fasthttp/middleware.go
@@ -3,7 +3,6 @@ package wasm
 import (
 	"context"
 	"strconv"
-	"sync"
 
 	"github.com/valyala/fasthttp"
 
@@ -27,18 +26,7 @@ func NewMiddleware(ctx context.Context, guest []byte, options ...httpwasm.Option
 	if err != nil {
 		return nil, err
 	}
-	// TODO: pool
-	g, err := r.NewGuest(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var mux sync.Mutex
-	handle := func(ctx context.Context) error {
-		mux.Lock()
-		defer mux.Unlock()
-		return g.Handle(ctx)
-	}
-	return &middleware{runtime: r, handle: handle}, nil
+	return &middleware{runtime: r, handle: r.Handle}, nil
 }
 
 type host struct{}

--- a/handler/fasthttp/middleware.go
+++ b/handler/fasthttp/middleware.go
@@ -18,7 +18,6 @@ var _ Middleware = &middleware{}
 
 type middleware struct {
 	runtime *internalhandler.Runtime
-	handle  func(ctx context.Context) error
 }
 
 func NewMiddleware(ctx context.Context, guest []byte, options ...httpwasm.Option) (Middleware, error) {
@@ -26,7 +25,7 @@ func NewMiddleware(ctx context.Context, guest []byte, options ...httpwasm.Option
 	if err != nil {
 		return nil, err
 	}
-	return &middleware{runtime: r, handle: r.Handle}, nil
+	return &middleware{runtime: r}, nil
 }
 
 type host struct{}
@@ -78,7 +77,7 @@ func (h host) SendResponse(ctx context.Context, statusCode uint32, body []byte) 
 
 // NewHandler implements the same method as documented on handler.Middleware.
 func (w *middleware) NewHandler(ctx context.Context, next fasthttp.RequestHandler) fasthttp.RequestHandler {
-	return (&guest{handle: w.handle, next: next}).Handle
+	return (&guest{handle: w.runtime.Handle, next: next}).Handle
 }
 
 // Close implements the same method as documented on handler.Middleware.

--- a/handler/nethttp/middleware.go
+++ b/handler/nethttp/middleware.go
@@ -13,8 +13,6 @@ type Middleware handler.Middleware[http.Handler]
 
 type middleware struct {
 	runtime *internalhandler.Runtime
-	// TODO: pool
-	handle func(ctx context.Context) error
 }
 
 func NewMiddleware(ctx context.Context, guest []byte, options ...httpwasm.Option) (Middleware, error) {
@@ -22,7 +20,7 @@ func NewMiddleware(ctx context.Context, guest []byte, options ...httpwasm.Option
 	if err != nil {
 		return nil, err
 	}
-	return &middleware{runtime: r, handle: r.Handle}, nil
+	return &middleware{runtime: r}, nil
 }
 
 type host struct{}
@@ -93,7 +91,7 @@ func (h host) SendResponse(ctx context.Context, statusCode uint32, body []byte) 
 
 // NewHandler implements the same method as documented on handler.Middleware.
 func (w *middleware) NewHandler(ctx context.Context, next http.Handler) http.Handler {
-	return &guest{handle: w.handle, next: next}
+	return &guest{handle: w.runtime.Handle, next: next}
 }
 
 // Close implements the same method as documented on handler.Middleware.

--- a/handler/nethttp/middleware.go
+++ b/handler/nethttp/middleware.go
@@ -3,7 +3,6 @@ package wasm
 import (
 	"context"
 	"net/http"
-	"sync"
 
 	httpwasm "github.com/http-wasm/http-wasm-host-go"
 	"github.com/http-wasm/http-wasm-host-go/api/handler"
@@ -23,18 +22,7 @@ func NewMiddleware(ctx context.Context, guest []byte, options ...httpwasm.Option
 	if err != nil {
 		return nil, err
 	}
-	// TODO: pool
-	g, err := r.NewGuest(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var mux sync.Mutex
-	handle := func(ctx context.Context) error {
-		mux.Lock()
-		defer mux.Unlock()
-		return g.Handle(ctx)
-	}
-	return &middleware{runtime: r, handle: handle}, nil
+	return &middleware{runtime: r, handle: r.Handle}, nil
 }
 
 type host struct{}

--- a/internal/handler/abi.go
+++ b/internal/handler/abi.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/tetratelabs/wazero"
 	wazeroapi "github.com/tetratelabs/wazero/api"
@@ -20,6 +21,7 @@ type Runtime struct {
 	newNamespace            httpwasm.NewNamespace
 	config                  wazero.ModuleConfig
 	logFn                   api.LogFunc
+	pool                    sync.Pool
 }
 
 func NewRuntime(ctx context.Context, guest []byte, host handler.Host, options ...httpwasm.Option) (*Runtime, error) {
@@ -50,7 +52,30 @@ func NewRuntime(ctx context.Context, guest []byte, host handler.Host, options ..
 		return nil, err
 	}
 
+	// Eagerly add a guest to the pool to catch initialization failure.
+	if g, err := r.newGuest(ctx); err != nil {
+		_ = r.Close(ctx)
+		return nil, err
+	} else {
+		r.pool.Put(g)
+	}
+
 	return r, nil
+}
+
+// Handle handles a request by calling the WebAssembly function export "handle" of the guest.
+func (r *Runtime) Handle(ctx context.Context) error {
+	poolG := r.pool.Get()
+	if poolG == nil {
+		g, err := r.newGuest(ctx)
+		if err != nil {
+			return err
+		}
+		poolG = g
+	}
+	g := poolG.(*guest)
+	defer r.pool.Put(g)
+	return g.handle(ctx)
 }
 
 // Close implements api.Closer
@@ -59,12 +84,12 @@ func (r *Runtime) Close(ctx context.Context) error {
 	return r.runtime.Close(ctx)
 }
 
-type Guest struct {
+type guest struct {
 	ns    wazero.Namespace
 	guest wazeroapi.Module
 }
 
-func (r *Runtime) NewGuest(ctx context.Context) (*Guest, error) {
+func (r *Runtime) newGuest(ctx context.Context) (*guest, error) {
 	ns, err := r.newNamespace(ctx, r.runtime)
 	if err != nil {
 		return nil, fmt.Errorf("wasm: error creating namespace: %w", err)
@@ -77,25 +102,19 @@ func (r *Runtime) NewGuest(ctx context.Context) (*Guest, error) {
 		return nil, fmt.Errorf("wasm: error instantiating host: %w", err)
 	}
 
-	guest, err := ns.InstantiateModule(ctx, r.guestModule, r.config)
+	g, err := ns.InstantiateModule(ctx, r.guestModule, r.config)
 	if err != nil {
 		_ = ns.Close(ctx)
 		return nil, fmt.Errorf("wasm: error instantiating guest: %w", err)
 	}
 
-	return &Guest{ns: ns, guest: guest}, nil
+	return &guest{ns: ns, guest: g}, nil
 }
 
 // Handle calls the WebAssembly function export "handle".
-func (g *Guest) Handle(ctx context.Context) (err error) {
+func (g *guest) handle(ctx context.Context) (err error) {
 	_, err = g.guest.ExportedFunction(handler.FuncHandle).Call(ctx)
 	return
-}
-
-// Close implements api.Closer
-func (g *Guest) Close(ctx context.Context) error {
-	// Closing the namespace closes both the host and guest modules
-	return g.ns.Close(ctx)
 }
 
 // getPath is the WebAssembly function export named handler.FuncGetPath which


### PR DESCRIPTION
This exposes a `Handle` method on `Runtime` instead of the `Guest` directly, allowing the handle method to take care of pooling so implementations don't need to. That allowed `Guest` to not be exposed at all, think that's fine but may have missed a use case for it