### PR TITLE
updates wazero to 1.0.0-pre.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/http-wasm/http-wasm-host-go
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.2.0.20221028153043-1ac6c06acb2e
+require github.com/tetratelabs/wazero v1.0.0-pre.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.2.0.20221028153043-1ac6c06acb2e h1:nmfueX9pRylEE0kJrz1k0Vk0l6BU+OUJZTWusuvTgTY=
-github.com/tetratelabs/wazero v1.0.0-pre.2.0.20221028153043-1ac6c06acb2e/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
+github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=

--- a/handler/mosn/go.mod
+++ b/handler/mosn/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/http-wasm/http-wasm-host-go v0.0.0-20221011003337-81d8f3916f05
-	github.com/tetratelabs/wazero v1.0.0-pre.2.0.20221028153043-1ac6c06acb2e
+	github.com/tetratelabs/wazero v1.0.0-pre.3
 	github.com/valyala/fasthttp v1.14.1-0.20200605121233-ac51d598dc54
 	mosn.io/api v1.1.0
 	mosn.io/mosn v1.1.0

--- a/handler/mosn/go.sum
+++ b/handler/mosn/go.sum
@@ -539,8 +539,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tebeka/strftime v0.1.3/go.mod h1:7wJm3dZlpr4l/oVK0t1HYIc4rMzQ2XJlOMIUJUJH6XQ=
-github.com/tetratelabs/wazero v1.0.0-pre.2.0.20221028153043-1ac6c06acb2e h1:nmfueX9pRylEE0kJrz1k0Vk0l6BU+OUJZTWusuvTgTY=
-github.com/tetratelabs/wazero v1.0.0-pre.2.0.20221028153043-1ac6c06acb2e/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
+github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3).

Notably, this improves performance and changes host function syntax.