### PR TITLE
Adds more rationale about concurrency

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -10,6 +10,11 @@ of initialized guests.
 The pool size is uncapped - any pool size cap would be a concurrency limit on
 the request handler. Production HTTP servers all have a native concept of
 concurrency limiting, so it would be redundant to have another way to limit
-concurrency here. Memory used by the middleware is similar to end-user business
-logic, and high memory usage in either would be handled the same way, by the
-HTTP server's concurrency limit mechanism.
+concurrency here.
+
+It is understood that guests use more memory than the same logic in native
+code. For example, some compilers default to a minimum of 16MB, and there is
+also overhead for the VM running the guest. This can imply running into a
+resource constraint faster than the same logic in native code. However, it
+is remains a better choice to address this with your HTTP server's
+concurrency limit mechanism.


### PR DESCRIPTION
This positions the rationale about pooling in a way more relevant to wasm. While wasm can reach a concurrency concern faster than native, this doesn't mean we should work around native concurrency control.

closes #42