### PR TITLE
deps: updates wazero to 1.0.0-pre.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/http-wasm/http-wasm-host-go
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4
+require github.com/tetratelabs/wazero v1.0.0-pre.6

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.6 h1:3DRqjuHazHyZmgWCgqu7nKgYIYNEi2+2RQpCwTqbVHs=
+github.com/tetratelabs/wazero v1.0.0-pre.6/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=

--- a/handler/cstring.go
+++ b/handler/cstring.go
@@ -32,7 +32,7 @@ func writeNULTerminated(
 	}
 
 	// Write the NUL-terminated string to memory directly.
-	s, ok := mem.Read(ctx, buf, byteCount)
+	s, ok := mem.Read(buf, byteCount)
 	if !ok {
 		panic("out of memory") // the guest passed a region outside memory.
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.6](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.6).

Notably, v1.0.0-pre.6:
* improves module compilation and initialization performance
* adds `writefs.NewDirFS` which lets you add new files.
  * `path_open` `O_CREAT` flags, `path_remove_directory` `path_rename` `path_unlink_file`
* adds `NewFilesystemLoggingListenerFactory` with dramatically improved logging.

This also includes changes described in [1.0.0-pre.5](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.5). Notably, context param was removed from memory functions as it was never used due to the scope being very narrow, and adds overhead to propagate.