### PR TITLE
deps: updates wazero to 1.0.0-pre.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/http-wasm/http-wasm-host-go
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.7
+require github.com/tetratelabs/wazero v1.0.0-pre.8

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.7 h1:WI5N14XxoXw+ZWhcjSazJ6rEowhJbH/x8hglxC5gN7k=
-github.com/tetratelabs/wazero v1.0.0-pre.7/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
+github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.8](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8) which notably
* Better supports WASI including third-party integrated tests
* Adds support for writeable filesystems via FSConfig
* Improves observability with LogScopes, e.g. filesystem.
* Obviates Namespace in favor of cheaper Runtimes sharing a CompilationCache

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>