### PR TITLE
deps: updates wazero to 1.0.0-rc.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/http-wasm/http-wasm-host-go
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-rc.1
+require github.com/tetratelabs/wazero v1.0.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-rc.1 h1:ytecMV5Ue0BwezjKh/cM5yv1Mo49ep2R2snSsQUyToc=
-github.com/tetratelabs/wazero v1.0.0-rc.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.0.0-rc.2 h1:OA3UUynnoqxrjCQ94mpAtdO4/oMxFQVNL2BXDMOc66Q=
+github.com/tetratelabs/wazero v1.0.0-rc.2/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-rc.2](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-rc.2) which notably
* is the final release candidate before 1.0 next Friday.
* improves instantiation performance (startup time)
* passes `os` package tests defined by Go.
* no longer supports importing unnamed modules.