### PR TITLE
deps: updates wazero to 1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/http-wasm/http-wasm-host-go
 
 go 1.19
 
-require github.com/tetratelabs/wazero v1.0.3
+require github.com/tetratelabs/wazero v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.3 h1:IWmaxc/5vKg71DE+c0SLjjLFAA3u3tD/Zegpgif2Wpo=
-github.com/tetratelabs/wazero v1.0.3/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.1.0 h1:EByoAhC+QcYpwSZJSs/aV0uokxPwBgKxfiokSUwAknQ=
+github.com/tetratelabs/wazero v1.1.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.1.0](https://github.com/tetratelabs/wazero/releases/tag/v1.1.0) which improves performance, reduces memory usage and adds new APIs for advanced users.

```bash
$ go test -run=^ -bench ^Benchmark/example_wasi ./... -count=6 > old.txt
$ go test -run=^ -bench ^Benchmark/example_wasi ./... -count=6 > new.txt
$ benchstat old.txt new.txt
benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/http-wasm/http-wasm-host-go/handler/nethttp
                              │   old.txt   │              new.txt              │
                              │   sec/op    │   sec/op     vs base              │
/example_wasi/example_wasi-12   3.274µ ± 1%   3.053µ ± 1%  -6.77% (p=0.002 n=6)
```