### PR TITLE
docs: moves note from ABI doc to HandleRequest godoc

### DIFF
--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -23,6 +23,9 @@ import (
 type Middleware interface {
 	// HandleRequest handles a request by calling handler.FuncHandleRequest on
 	// the guest.
+	//
+	// Note: If the handler.CtxNext is returned with `next=1`, you must call
+	// HandleResponse.
 	HandleRequest(ctx context.Context) (outCtx context.Context, ctxNext handler.CtxNext, err error)
 
 	// HandleResponse handles a response by calling handler.FuncHandleResponse
@@ -143,8 +146,7 @@ func (m *middleware) HandleRequest(ctx context.Context) (outCtx context.Context,
 
 	s := &requestState{features: m.features, putPool: m.pool.Put, g: g}
 	defer func() {
-		callNext := ctxNext != 0
-		if callNext { // will call the next handler
+		if ctxNext != 0 { // will call the next handler
 			if closeErr := s.closeRequest(); err == nil {
 				err = closeErr
 			}

--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -150,7 +150,7 @@ func (m *middleware) HandleRequest(ctx context.Context) (outCtx context.Context,
 			if closeErr := s.closeRequest(); err == nil {
 				err = closeErr
 			}
-		} else { // will return the response
+		} else { // guest errored or returned the response
 			if closeErr := s.Close(); err == nil {
 				err = closeErr
 			}

--- a/handler/state.go
+++ b/handler/state.go
@@ -45,7 +45,10 @@ func (r *requestState) closeRequest() (err error) {
 	return
 }
 
-// Close implements io.Closer
+// Close releases all resources for the current request, including:
+//   - putting the guest module back into the pool
+//   - releasing any request body resources
+//   - releasing any response body resources
 func (r *requestState) Close() (err error) {
 	if g := r.g; g != nil {
 		r.putPool(r.g)


### PR DESCRIPTION
The ABI says this, and we didn't. If someone forgets to call this, they will leak a module.

```
handle_response: caller by the host, regardless of error, when handle_request returned next=1.
```