### PR TITLE
deps: updates wazero to 1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/http-wasm/http-wasm-host-go
 
 go 1.19
 
-require github.com/tetratelabs/wazero v1.1.0
+require github.com/tetratelabs/wazero v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.1.0 h1:EByoAhC+QcYpwSZJSs/aV0uokxPwBgKxfiokSUwAknQ=
-github.com/tetratelabs/wazero v1.1.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.2.0 h1:I/8LMf4YkCZ3r2XaL9whhA0VMyAvF6QE+O7rco0DCeQ=
+github.com/tetratelabs/wazero v1.2.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.2.0](https://github.com/tetratelabs/wazero/releases/tag/v1.2.0) which improves performance, interop and debug.

Benchmarks improved notably in wasi. Remember this is raw webassembly (%.wat) so any improvements are hard to get!
```bash
$ benchstat old.txt new.txt 
goos: darwin
goarch: arm64
pkg: github.com/http-wasm/http-wasm-host-go/handler/nethttp
                                                                │   old.txt   │              new.txt              │
                                                                │   sec/op    │   sec/op     vs base              │
/get_header_names_none/get_header_names_none-12                   546.7n ± 1%   549.8n ± 2%       ~ (p=0.485 n=6)
/read_body/read_body-12                                           482.9n ± 1%   485.3n ± 2%       ~ (p=0.699 n=6)
/get_header_names_large/get_header_names_large-12                 1.040µ ± 1%   1.044µ ± 1%       ~ (p=0.169 n=6)
/remove_header/remove_header-12                                   497.2n ± 2%   499.3n ± 1%       ~ (p=1.000 n=6)
/read_body_stream/read_body_stream-12                             501.1n ± 3%   485.9n ± 1%       ~ (p=0.065 n=6)
/read_body_stream_large/read_body_stream_large-12                 602.9n ± 3%   600.9n ± 1%       ~ (p=0.132 n=6)
/write_body/write_body-12                                         458.1n ± 2%   459.8n ± 2%       ~ (p=0.310 n=6)
/example_wasi/example_wasi-12                                     3.055µ ± 3%   2.901µ ± 1%  -5.03% (p=0.002 n=6)
/log/log-12                                                       433.2n ± 0%   433.1n ± 1%       ~ (p=1.000 n=6)
/get_header_names/get_header_names-12                             527.0n ± 1%   525.1n ± 1%       ~ (p=0.461 n=6)
/get_header_values_not_exists/get_header_values_not_exists-12     485.4n ± 1%   485.4n ± 5%       ~ (p=0.937 n=6)
/set_header_value/set_header_value-12                             597.2n ± 1%   594.1n ± 3%       ~ (p=0.377 n=6)
/add_header_value/add_header_value-12                             592.6n ± 1%   597.4n ± 2%       ~ (p=0.394 n=6)
/set_status_code/set_status_code-12                               445.2n ± 1%   445.1n ± 1%       ~ (p=0.937 n=6)
/example_router_host_response/example_router_host_response-12     553.1n ± 1%   549.8n ± 0%  -0.61% (p=0.041 n=6)
/set_uri/set_uri-12                                               567.6n ± 1%   562.9n ± 3%       ~ (p=0.093 n=6)
/get_header_values_exists/get_header_values_exists-12             468.4n ± 1%   465.2n ± 1%  -0.69% (p=0.019 n=6)
/example_router_guest_response/example_router_guest_response-12   624.0n ± 1%   621.9n ± 1%       ~ (p=1.000 n=6)
/get_uri/get_uri-12                                               463.1n ± 1%   464.8n ± 4%       ~ (p=0.589 n=6)
geomean                                                           588.9n        586.3n       -0.45%
```