### PR TITLE
fix: fixes parameter names.

### DIFF
--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -691,10 +691,10 @@ func (m *middleware) instantiateHost(ctx context.Context) (wazeroapi.Module, err
 		WithParameterNames("kind", "name", "name_len", "buf", "buf_limit").Export(handler.FuncGetHeaderValues).
 		NewFunctionBuilder().
 		WithGoModuleFunction(wazeroapi.GoModuleFunc(m.setHeaderValue), []wazeroapi.ValueType{i32, i32, i32, i32, i32}, []wazeroapi.ValueType{}).
-		WithParameterNames("kind", "name", "name_len", "value", "value").Export(handler.FuncSetHeaderValue).
+		WithParameterNames("kind", "name", "name_len", "value", "value_len").Export(handler.FuncSetHeaderValue).
 		NewFunctionBuilder().
 		WithGoModuleFunction(wazeroapi.GoModuleFunc(m.addHeaderValue), []wazeroapi.ValueType{i32, i32, i32, i32, i32}, []wazeroapi.ValueType{}).
-		WithParameterNames("kind", "name", "name_len", "value", "value").Export(handler.FuncAddHeaderValue).
+		WithParameterNames("kind", "name", "name_len", "value", "value_len").Export(handler.FuncAddHeaderValue).
 		NewFunctionBuilder().
 		WithGoModuleFunction(wazeroapi.GoModuleFunc(m.removeHeader), []wazeroapi.ValueType{i32, i32, i32}, []wazeroapi.ValueType{}).
 		WithParameterNames("kind", "name", "name_len").Export(handler.FuncRemoveHeader).


### PR DESCRIPTION
This one did not look correct but I am not 100% sure it is a bug and also how to test it. I tried

```

type testHost struct {
	t *testing.T
	handler.UnimplementedHost
}

func (h testHost) SetRequestHeaderValue(ctx context.Context, key, value string) {
	h.t.Log(key, value)
	h.t.Fail()
}

func TestMiddlewareExposesFunctionsCorrectly(t *testing.T) {
	mw, err := NewMiddleware(testCtx, test.BinE2EHeaderValue, testHost{t, handler.UnimplementedHost{}})
	requireEqualError(t, err, "")
	mw.HandleRequest(context.Background())
}

```
and I get the right values for `key` and `value`.