### PR TITLE
fix: fix wasm middleware guest module instance  memory leak issue

### DIFF
--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -171,6 +172,15 @@ func (m *middleware) getOrCreateGuest(ctx context.Context) (*guest, error) {
 		if g, createErr := m.newGuest(ctx); createErr != nil {
 			return nil, createErr
 		} else {
+			runtime.SetFinalizer(g, func(g *guest) {
+				if err := g.guest.Close(context.Background()); err != nil {
+					fmt.Printf("[http-wasm-host-go] middleware wazeroapi guest module close err: %v", err)
+				} else {
+					g.guest = nil
+					g.handleRequestFn = nil
+					g.handleResponseFn = nil
+				}
+			})
 			poolG = g
 		}
 	}

--- a/handler/nethttp/middleware.go
+++ b/handler/nethttp/middleware.go
@@ -3,12 +3,11 @@ package wasm
 import (
 	"context"
 	"fmt"
+	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
+	"github.com/http-wasm/http-wasm-host-go/handler"
 	"io"
 	"net/http"
 	"runtime"
-
-	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
-	"github.com/http-wasm/http-wasm-host-go/handler"
 )
 
 // compile-time checks to ensure interfaces are implemented.
@@ -26,13 +25,7 @@ func NewMiddleware(ctx context.Context, guest []byte, options ...handler.Option)
 		return nil, err
 	}
 
-	mw := &middleware{m: m}
-	runtime.SetFinalizer(mw, func(mw *middleware) {
-		if err := mw.Close(ctx); err != nil {
-			fmt.Printf("[http-wasm-host-go] middleware Close failed: %v", err)
-		}
-	})
-	return mw, nil
+	return &middleware{m: m}, nil
 }
 
 // requestStateKey is a context.Context value associated with a requestState
@@ -95,12 +88,18 @@ func requestStateFromContext(ctx context.Context) *requestState {
 
 // NewHandler implements the same method as documented on handler.Middleware.
 func (w *middleware) NewHandler(_ context.Context, next http.Handler) http.Handler {
-	return &guest{
+	h := &guest{
 		handleRequest:  w.m.HandleRequest,
 		handleResponse: w.m.HandleResponse,
 		next:           next,
 		features:       w.m.Features(),
 	}
+	runtime.SetFinalizer(h, func(h *guest) {
+		if err := w.Close(context.Background()); err != nil {
+			fmt.Printf("[http-wasm-host-go] middleware Close failed: %v", err)
+		}
+	})
+	return h
 }
 
 // Close implements the same method as documented on handler.Middleware.

--- a/handler/nethttp/middleware.go
+++ b/handler/nethttp/middleware.go
@@ -3,12 +3,10 @@ package wasm
 import (
 	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"runtime"
-
 	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
 	"github.com/http-wasm/http-wasm-host-go/handler"
+	"io"
+	"net/http"
 )
 
 // compile-time checks to ensure interfaces are implemented.
@@ -89,18 +87,12 @@ func requestStateFromContext(ctx context.Context) *requestState {
 
 // NewHandler implements the same method as documented on handler.Middleware.
 func (w *middleware) NewHandler(_ context.Context, next http.Handler) http.Handler {
-	h := &guest{
+	return &guest{
 		handleRequest:  w.m.HandleRequest,
 		handleResponse: w.m.HandleResponse,
 		next:           next,
 		features:       w.m.Features(),
 	}
-	runtime.SetFinalizer(h, func(h *guest) {
-		if err := w.Close(context.Background()); err != nil {
-			fmt.Printf("[http-wasm-host-go] middleware Close failed: %v", err)
-		}
-	})
-	return h
 }
 
 // Close implements the same method as documented on handler.Middleware.

--- a/handler/nethttp/middleware.go
+++ b/handler/nethttp/middleware.go
@@ -3,10 +3,11 @@ package wasm
 import (
 	"context"
 	"fmt"
-	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
-	"github.com/http-wasm/http-wasm-host-go/handler"
 	"io"
 	"net/http"
+
+	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
+	"github.com/http-wasm/http-wasm-host-go/handler"
 )
 
 // compile-time checks to ensure interfaces are implemented.

--- a/handler/nethttp/middleware.go
+++ b/handler/nethttp/middleware.go
@@ -3,11 +3,12 @@ package wasm
 import (
 	"context"
 	"fmt"
-	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
-	"github.com/http-wasm/http-wasm-host-go/handler"
 	"io"
 	"net/http"
 	"runtime"
+
+	handlerapi "github.com/http-wasm/http-wasm-host-go/api/handler"
+	"github.com/http-wasm/http-wasm-host-go/handler"
 )
 
 // compile-time checks to ensure interfaces are implemented.


### PR DESCRIPTION
###  fixup guest module instance creation without guest module free caused memory leak

related issue: https://github.com/traefik/traefik/issues/11119

related PR: https://github.com/traefik/http-wasm-host-go/pull/2

cc @juliens 

-------------------------------------------------------------

since this implementation make usage of `sync.Pool`

we must call `Close()` method of the module when the sync.Pool object got GC ed.

without call `Close()` to releases resources allocated for this Module, the memory will leak

-------------------------------------------------------------


###  related PR

see also https://github.com/traefik/traefik/pull/11151 which fixup the wasm plugin memory leak when dynamic config loading ( which cause all related route middleware recreation), we have to call `nethttp.middleware.Close()` (which will call `handler.middleware.Close()` -> `wazero.Runtime.Close()` ) to free the memory

