### PR TITLE
Remove printf and add a log

### DIFF
--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -174,7 +174,7 @@ func (m *middleware) getOrCreateGuest(ctx context.Context) (*guest, error) {
 		} else {
 			runtime.SetFinalizer(g, func(g *guest) {
 				if err := g.guest.Close(context.Background()); err != nil {
-					fmt.Printf("[http-wasm-host-go] middleware wazeroapi guest module close err: %v", err)
+					m.logger.Log(ctx, api.LogLevelDebug, fmt.Sprintf("[http-wasm-host-go] middleware wazeroapi guest module close err: %v", err))
 				} else {
 					g.guest = nil
 					g.handleRequestFn = nil


### PR DESCRIPTION
This PR removes a fmt.Printf to use a log instead.